### PR TITLE
Fix send head data size

### DIFF
--- a/event-driven-model/epoll-server.c
+++ b/event-driven-model/epoll-server.c
@@ -215,7 +215,7 @@ int main(int argc, char* argv[]) {
         }
 
         char *head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
-        count = write(events[i].data.fd, head, sizeof head);
+        count = write(events[i].data.fd, head, strlen(head));
         if (count == -1 && errno != EAGAIN) {
           perror("write");
           close(events[i].data.fd);


### PR DESCRIPTION
Use `strlen(head)` instead of `sizeof head` to send full head. 
`sizeof head` sends only size of pointer bytes (i.e. first 4 bytes on 32-bit systems or 8 bytes on 64-bit systems).